### PR TITLE
finding a module only is not a parsing error

### DIFF
--- a/client.go
+++ b/client.go
@@ -155,6 +155,8 @@ func (c *client) DescribePackage(req DescribePackageRequest) (*Package, error) {
 	col.OnHTML(".UnitHeader-titleHeading", func(e *colly.HTMLElement) {
 		for next := e.DOM.Next(); ; next = next.Next() {
 			switch next.Text() {
+			case "command":
+				//pass
 			case "package":
 				p.IsPackage = true
 			case "module":


### PR DESCRIPTION
First, thanks for creating this tool.

While using it to find the licenses to some dependencies I have in another project, I found that it will outputs a parse error if a library is defined only as a `module` on pkg.go.dev (ex: `https://pkg.go.dev/github.com/flier/gohs`)

Example to replicate the issue:
```
# ./pkggodev package-info github.com/flier/gohs
errors: [IsPackage=false after parsing page for 'github.com/flier/gohs', this probably indicates a parsing bug]
```

Seems this is because seeing a library as only being a module produces the parse error. This PR addresses this and the command above now produces the right output:
```
# ./pkggodev package-info github.com/flier/gohs
Package:                        github.com/flier/gohs
IsModule:                       true
IsPackage:                      false
Version:                        v1.1.0
Published:                      2021-03-26
License:                        Apache-2.0, MIT
HasValidGoModFile:              true
HasRedistributableLicense:      true
HasTaggedVersion:               true
HasStableVersion:               true
Repository:                     github.com/flier/gohs
```