### PR TITLE
fix version date parse

### DIFF
--- a/client.go
+++ b/client.go
@@ -292,6 +292,7 @@ func (c *client) Versions(req VersionsRequest) (*Versions, error) {
 			}
 			// this means there are changes, and it's also the end of the entry
 			if s.HasClass("Version-details") {
+				s.Find(".Version-summary").Find("span").Remove()
 				dateStr := strings.TrimSpace(s.Find(".Version-summary").Text())
 				t, err := normalizeTime(dateStr)
 				if err != nil {


### PR DESCRIPTION
fix version date parser for versions with links to the reports fixed

for example: https://pkg.go.dev/golang.org/x/net?tab=versions